### PR TITLE
Add `DeleteOnDrop{Counter,Gauge}`

### DIFF
--- a/src/counter.rs
+++ b/src/counter.rs
@@ -57,6 +57,14 @@ impl<P: Atomic> GenericCounter<P> {
         Ok(Self { v: Arc::new(v) })
     }
 
+    /// The fully qualified name for this counter
+    ///
+    /// This is the name with no labels, and corresponds to `desc().fq_name` on
+    /// the [`Collector`] trait.
+    pub fn fq_name(&self) -> &str {
+        &self.v.desc.fq_name
+    }
+
     /// Increase the given value to the counter.
     ///
     /// # Panics

--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -56,6 +56,14 @@ impl<P: Atomic> GenericGauge<P> {
         Ok(Self { v: Arc::new(v) })
     }
 
+    /// The fully qualified name for this gauge
+    ///
+    /// This is the name with no labels, and corresponds to `desc().fq_name` on
+    /// the [`Collector`] trait.
+    pub fn fq_name(&self) -> &str {
+        &self.v.desc.fq_name
+    }
+
     /// Set the gauge to an arbitrary value.
     #[inline]
     pub fn set(&self, v: P::T) {

--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -2,6 +2,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::marker::PhantomData;
+use std::ops::Deref;
 use std::sync::Arc;
 
 use crate::atomic64::{Atomic, AtomicF64, AtomicI64, AtomicU64, Number};
@@ -165,6 +166,103 @@ impl<P: Atomic> GenericGaugeVec<P> {
         let metric_vec = MetricVec::create(proto::MetricType::GAUGE, GaugeVecBuilder::new(), opts)?;
 
         Ok(metric_vec as Self)
+    }
+}
+
+/// A [`GenericGauge`] wrapper that deletes its labels from the vec when it is dropped
+///
+/// Passing a `GenericGauge` to this with the `GenericGaugeVec` that it was
+/// created will cause the labels associated with the gauge to be deleted when
+/// it is dropped. This is mostly useful for environments where the [`Gauge`]
+/// is created and persists as long as the item that it is providing metrics for.
+///
+/// # Example
+///
+/// ```
+/// use prometheus::{Gauge, GaugeVec, DeleteOnDropGauge, Opts, core::AtomicF64};
+///
+/// struct UserTracker<'a> {
+///     user: String,
+///     metric: DeleteOnDropGauge<'a, AtomicF64>,
+/// }
+///
+/// fn do_stuff_with(u: &UserTracker) {}
+///
+/// fn main() {
+///     let vec = GaugeVec::new(
+///         Opts::new("user_actions", "example help"),
+///         &["user"],
+///     ).unwrap();
+///     {
+///         let user = UserTracker {
+///             user: "Name".into(),
+///             metric: DeleteOnDropGauge::new(vec.with_label_values(&["Name"]), &vec),
+///         };
+///         do_stuff_with(&user);
+///     } // labels are dropped here
+/// }
+/// ```
+#[derive(Debug)]
+pub struct DeleteOnDropGauge<
+    'a,
+    P: Atomic,
+    F: FnOnce(crate::Error, &GenericGauge<P>) = fn(crate::Error, &GenericGauge<P>),
+> {
+    inner: GenericGauge<P>,
+    vec: &'a GenericGaugeVec<P>,
+    error_handler: Option<F>,
+}
+
+impl<'a, P: Atomic> DeleteOnDropGauge<'a, P, fn(crate::Error, &GenericGauge<P>)> {
+    /// Create a `DeleteOnDropGauge`
+    pub fn new(
+        gauge: GenericGauge<P>,
+        vec: &'a GenericGaugeVec<P>,
+    ) -> DeleteOnDropGauge<'a, P, fn(crate::Error, &GenericGauge<P>)> {
+        DeleteOnDropGauge {
+            inner: gauge,
+            vec,
+            error_handler: None,
+        }
+    }
+}
+
+impl<'a, P: Atomic, F: FnOnce(crate::Error, &GenericGauge<P>)> DeleteOnDropGauge<'a, P, F> {
+    /// Create a `DeleteOnDropGauge`
+    ///
+    /// The `error_handler` will be called on drop if the labels are not known
+    /// to the `GaugeVec` at the time of drop.
+    pub fn new_with_error_handler(
+        gauge: GenericGauge<P>,
+        vec: &'a GenericGaugeVec<P>,
+        error_handler: F,
+    ) -> DeleteOnDropGauge<'a, P, F> {
+        DeleteOnDropGauge {
+            inner: gauge,
+            vec,
+            error_handler: Some(error_handler),
+        }
+    }
+}
+
+impl<'a, P: Atomic, F: FnOnce(crate::Error, &GenericGauge<P>)> Deref
+    for DeleteOnDropGauge<'a, P, F>
+{
+    type Target = GenericGauge<P>;
+    fn deref(&self) -> &GenericGauge<P> {
+        &self.inner
+    }
+}
+
+impl<'a, P: Atomic, F: FnOnce(crate::Error, &GenericGauge<P>)> Drop
+    for DeleteOnDropGauge<'a, P, F>
+{
+    fn drop(&mut self) {
+        if let Err(e) = self.vec.v.delete_label_pairs(&self.inner.v.label_pairs) {
+            if let Some(eh) = self.error_handler.take() {
+                eh(e, &self.inner);
+            }
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,8 @@ pub mod core {
 }
 
 pub use self::counter::{
-    Counter, CounterVec, IntCounter, IntCounterVec, UIntCounter, UIntCounterVec,
+    Counter, CounterVec, DeleteOnDropCounter, IntCounter, IntCounterVec, UIntCounter,
+    UIntCounterVec,
 };
 pub use self::encoder::Encoder;
 #[cfg(feature = "protobuf")]
@@ -190,7 +191,9 @@ pub use self::encoder::TextEncoder;
 #[cfg(feature = "protobuf")]
 pub use self::encoder::{PROTOBUF_FORMAT, TEXT_FORMAT};
 pub use self::errors::{Error, Result};
-pub use self::gauge::{Gauge, GaugeVec, IntGauge, IntGaugeVec, UIntGauge, UIntGaugeVec};
+pub use self::gauge::{
+    DeleteOnDropGauge, Gauge, GaugeVec, IntGauge, IntGaugeVec, UIntGauge, UIntGaugeVec,
+};
 pub use self::histogram::DEFAULT_BUCKETS;
 pub use self::histogram::{exponential_buckets, linear_buckets};
 pub use self::histogram::{Histogram, HistogramOpts, HistogramTimer, HistogramVec};


### PR DESCRIPTION
Quoting the docs for one of them:

A `GenericGauge` wrapper that deletes its labels from the vec when it is dropped

Passing a `GenericGauge` to this with the `GenericGaugeVec` that it was
created will cause the labels associated with the gauge to be deleted when
it is dropped. This is mostly useful for environments where the `Gauge`
is created and persists as long as the item that it is providing metrics for.

## Example

```rust
use prometheus::{Gauge, GaugeVec, DeleteOnDropGauge, Opts, core::AtomicF64};

struct UserTracker<'a> {
    user: String,
    metric: DeleteOnDropGauge<'a, AtomicF64>,
}

fn do_stuff_with(u: &UserTracker) {}

fn main() {
    let vec = GaugeVec::new(
        Opts::new("user_actions", "example help"),
        &["user"],
    ).unwrap();
    {
        let user = UserTracker {
            user: "Name".into(),
            metric: DeleteOnDropGauge::new(vec.with_label_values(&["Name"]), &vec),
        };
        do_stuff_with(&user);
    } // labels are dropped here
}
```