### PR TITLE
Update license field in static-metric-proc-macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ keywords = ["prometheus", "metrics"]
 authors = ["overvenus@gmail.com", "siddontang@gmail.com", "vistaswx@gmail.com"]
 description = "Prometheus instrumentation library for Rust applications."
 readme = "README.md"
-repository = "https://github.com/pingcap/rust-prometheus"
-homepage = "https://github.com/pingcap/rust-prometheus"
+repository = "https://github.com/tikv/rust-prometheus"
+homepage = "https://github.com/tikv/rust-prometheus"
 documentation = "https://docs.rs/prometheus"
 edition = "2018"
 

--- a/static-metric/Cargo.toml
+++ b/static-metric/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.3.0"
 license = "Apache-2.0"
 authors = ["me@breeswish.org"]
 description = "Static metric helper utilities for rust-prometheus."
-repository = "https://github.com/pingcap/rust-prometheus"
-homepage = "https://github.com/pingcap/rust-prometheus"
+repository = "https://github.com/tikv/rust-prometheus"
+homepage = "https://github.com/tikv/rust-prometheus"
 documentation = "https://docs.rs/prometheus-static-metric"
 include = [
     "LICENSE",

--- a/static-metric/README.md
+++ b/static-metric/README.md
@@ -3,7 +3,7 @@
 [![docs.rs](https://docs.rs/prometheus-static-metric/badge.svg)](https://docs.rs/prometheus-static-metric)
 [![crates.io](http://meritbadge.herokuapp.com/prometheus-static-metric)](https://crates.io/crates/prometheus-static-metric)
 
-Utility macro to build static metrics for the [rust-prometheus](https://github.com/pingcap/rust-prometheus) library.
+Utility macro to build static metrics for the [rust-prometheus](https://github.com/tikv/rust-prometheus) library.
 
 ## Why?
 

--- a/static-metric/proc-macros/Cargo.toml
+++ b/static-metric/proc-macros/Cargo.toml
@@ -3,6 +3,8 @@ name = "static-metric-proc-macros"
 version = "0.1.0"
 authors = ["Yilin Chen <sticnarf@gmail.com>"]
 edition = "2018"
+repository = "https://github.com/tikv/rust-prometheus"
+homepage = "https://github.com/tikv/rust-prometheus"
 license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/static-metric/proc-macros/Cargo.toml
+++ b/static-metric/proc-macros/Cargo.toml
@@ -3,6 +3,7 @@ name = "static-metric-proc-macros"
 version = "0.1.0"
 authors = ["Yilin Chen <sticnarf@gmail.com>"]
 edition = "2018"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/static-metric/proc-macros/src/auto_flush_from.rs
+++ b/static-metric/proc-macros/src/auto_flush_from.rs
@@ -1,3 +1,5 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
 use proc_macro2::Span;
 use syn::export::TokenStream2;
 use syn::parse::{Parse, ParseStream};


### PR DESCRIPTION
All but one of the files inside the crate have the Apache2 header.